### PR TITLE
Fix tabs, and force noexpandtab using vim modelines

### DIFF
--- a/graphics.c
+++ b/graphics.c
@@ -403,3 +403,4 @@ uint32_t gr_getms ()
 	return SDL_GetTicks ();
 }
 
+/* vim: set noexpandtab ts=4 sts=4 sw=4 : */

--- a/graphics.h
+++ b/graphics.h
@@ -63,3 +63,4 @@ void gr_resize    (int, int);
 
 #endif /* GRAPHICS_H_INCLUDED */
 
+/* vim: set noexpandtab ts=4 sts=4 sw=4 : */

--- a/main.c
+++ b/main.c
@@ -331,11 +331,11 @@ void draw_level (struct LevelState *ls)
 	char *level = ls->level;
 	int levelw = ls->levelw;
 	for (y = 0; y < gr_ph; ++ y)
-    {
-        int colour = PIXEL_VALUE(255,255,y<gr_ph/2 ? 255-2*(y*255)/gr_ph : 0);
-        for (x = 0; x < gr_pw; ++ x)
-            gr_pixels[y*gr_pw + x] = colour;
-    }
+	{
+		int colour = PIXEL_VALUE(255,255,y<gr_ph/2 ? 255-2*(y*255)/gr_ph : 0);
+		for (x = 0; x < gr_pw; ++ x)
+			gr_pixels[y*gr_pw + x] = colour;
+	}
 	for (w = 0; level[w]; ++ w)
 	{
 		int L = (w%levelw)*blockwidth, R = L + blockwidth,
@@ -596,3 +596,4 @@ int main ()
 		return 0;
 }
 
+/* vim: set noexpandtab ts=4 sts=4 sw=4 : */

--- a/vector.c
+++ b/vector.c
@@ -81,3 +81,4 @@ int v_isin (Vector vec, void *data)
 	return 0;
 }
 
+/* vim: set noexpandtab ts=4 sts=4 sw=4 : */

--- a/vector.h
+++ b/vector.h
@@ -31,3 +31,4 @@ void    v_print (Vector);
 
 #endif /* VECTOR_H_INCLUDED */
 
+/* vim: set noexpandtab ts=4 sts=4 sw=4 : */


### PR DESCRIPTION
To use this you must have the following in your `.vimrc`:
```
set modeline
```